### PR TITLE
Feature/instagram_feed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,9 @@
  *
  * See: https://www.gatsbyjs.org/docs/gatsby-config/
  */
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
 
 module.exports = {
   /* Your site config here */

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,7 @@ require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
+
 module.exports = {
   /* Your site config here */
   plugins: [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
+    "axios": "^0.19.2",
+    "dotenv": "^8.2.0",
     "gatsby": "^2.23.12",
     "gatsby-plugin-typography": "^2.5.10",
     "gatsby-remark-smartypants": "^2.3.10",

--- a/src/components/about/instagramFeed.js
+++ b/src/components/about/instagramFeed.js
@@ -1,0 +1,14 @@
+import React from "react"
+import styles from "./instagramFeed.module.css"
+
+function Feed({ thumnail, link }) {
+    return (
+        <div className={styles.feed}>
+            <a href={link}>
+                <img src={thumnail} alt="이미지를 찾을 수 없습니다." />
+            </a>
+        </div>
+    );
+}
+
+export default Feed;

--- a/src/components/about/instagramFeed.module.css
+++ b/src/components/about/instagramFeed.module.css
@@ -1,0 +1,7 @@
+.feed {
+  max-width: 250px;
+  max-height: 250px;
+  float: left;
+  padding: 20px;
+  overflow: hidden;
+}

--- a/src/configs/index.js
+++ b/src/configs/index.js
@@ -1,0 +1,3 @@
+export default {
+    ACCESS_TOKEN: process.env.REACT_APP_ACCESS_TOKEN
+}

--- a/src/configs/index.js
+++ b/src/configs/index.js
@@ -1,3 +1,3 @@
 export default {
-    ACCESS_TOKEN: process.env.REACT_APP_ACCESS_TOKEN
+    ACCESS_TOKEN: process.env.GATSBY_INSTAGRAM_ACCESS_TOKEN,
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,6 @@ import Feed from "../components/about/instagramFeed"
 
 export default function Studies({ location }) {
 
-  const accessToken = configs.ACCESS_TOKEN
   const [instagrams, setInstagram] = useState([]);
 
   useEffect(() => {
@@ -15,7 +14,7 @@ export default function Studies({ location }) {
   }, [])
 
   const getInstagram = async () => {
-    const res = await axios.get(`https://graph.instagram.com/me/media?fields=media_type,media_url,permalink&access_token=${accessToken}`)
+    const res = await axios.get(`https://graph.instagram.com/me/media?fields=media_type,media_url,permalink&access_token=${configs.ACCESS_TOKEN}`)
     setInstagram(res.data.data)
   }
 
@@ -115,7 +114,6 @@ export default function Studies({ location }) {
           </ul>
         </div>
         <div className="temp feeds">
-          <h3>FORIF Instagram</h3>
           {instagrams.map(feed => (
             <Feed thumnail={feed.media_url} link={feed.permalink} />
           ))}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,27 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import Layout from "../components/layout/layout"
 import styles from "./index.module.css"
+import axios from "axios"
+import configs from "../configs"
 
 export default function Studies({ location }) {
+
+  const accessToken = configs.ACCESS_TOKEN
+  const [instagrams, setInstagram] = useState([]);
+
+  useEffect(() => {
+    getInstagram();
+  }, [])
+
+  const getInstagram = async () => {
+    const res = await axios.get(`https://graph.instagram.com/me/media?fields=media_type,media_url,permalink&access_token=${accessToken}`)
+    setInstagram(res.data.data)
+  }
+
+  const tempStyle = {
+    width: "200px",
+  }
+
   return (
     <Layout sideList={0} pathName={location.pathname}>
       <div className={styles.layoutWrapper}>
@@ -97,6 +116,12 @@ export default function Studies({ location }) {
               <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit.</p>
             </li>
           </ul>
+        </div>
+        <div className="temp feeds">
+          <h3>FORIF Instagram</h3>
+          {instagrams.map(feed => (
+            <a href={feed.permalink}><img src={feed.media_url} alt="thum" style={tempStyle}></img></a>
+          ))}
         </div>
       </div>
     </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,6 +3,7 @@ import Layout from "../components/layout/layout"
 import styles from "./index.module.css"
 import axios from "axios"
 import configs from "../configs"
+import Feed from "../components/about/instagramFeed"
 
 export default function Studies({ location }) {
 
@@ -16,10 +17,6 @@ export default function Studies({ location }) {
   const getInstagram = async () => {
     const res = await axios.get(`https://graph.instagram.com/me/media?fields=media_type,media_url,permalink&access_token=${accessToken}`)
     setInstagram(res.data.data)
-  }
-
-  const tempStyle = {
-    width: "200px",
   }
 
   return (
@@ -120,7 +117,7 @@ export default function Studies({ location }) {
         <div className="temp feeds">
           <h3>FORIF Instagram</h3>
           {instagrams.map(feed => (
-            <a href={feed.permalink}><img src={feed.media_url} alt="thum" style={tempStyle}></img></a>
+            <Feed thumnail={feed.media_url} link={feed.permalink} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
인스타그램API를 사용해서 루트 페이지 HISTORY 하단에 포리프 인스타 피드를 불러왔습니다.

CSS는 아직 넣지 않았습니다.

인스타그램API를 사용하는 과정에서 토큰을 사용하기 때문에 .env를 사용했습니다. 결과 예시는 [이곳](https://forif.netlify.app/)에서 볼 수 있습니다. 네트워크 환경에 따라 로딩 시간이 좀 걸릴 수 있습니다.

로컬 환경에서 실행해보고 싶으신 분들은 따로 연락주시면 .env파일 설정하는 법과 토큰 값을 알려드리겠습니다.