### PR TITLE
[DELETE] staffs min-width

### DIFF
--- a/src/components/staffs/Profile.module.css
+++ b/src/components/staffs/Profile.module.css
@@ -116,12 +116,6 @@
     .jobTitle{
         font-size: 13px;
     }
-    .profileCells {
-        display: flex;
-        flex-wrap: nowrap;
-        justify-content: space-evenly;
-        min-width: 455px;
-    }
     .profileImage {
         width: 35px;
         height: 35px;


### PR DESCRIPTION
445px이하에서 메인 컴포넌트가 (레이아웃과 동일한 방식으로) 뷰포트에 맞추어 보이도록 min-width를 삭제했습니다.