### PR TITLE
[DELETE] hackathon min-width

### DIFF
--- a/src/components/hackaton/HackOverview.module.css
+++ b/src/components/hackaton/HackOverview.module.css
@@ -131,9 +131,6 @@
     .semester{
         font-size: 13px;
     }
-    .productCells{
-        min-width: 360px;
-    }
     .productCell{
         width: 115px;
         height: 150px;


### PR DESCRIPTION
모바일 화면에서 메인 컴포넌트가 (레이아웃과 동일한 방식으로) 뷰포트에 맞추어 보이도록 min-width를 삭제했습니다.